### PR TITLE
cargo fixes

### DIFF
--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -76,7 +76,7 @@ pub fn ws_terr_changes(
                 TerrSockMessage::Territory(hash_map) => {
                     terrs.write().extend(hash_map);
                 }
-                TerrSockMessage::Capture { name, old: Territory, new } => {
+                TerrSockMessage::Capture { name, old, new } => {
                     terrs.write().insert(name, new);
                 }
             }

--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -28,7 +28,7 @@ pub async fn load_map_tiles() -> Option<Vec<WynntilsMapTile>> {
     Some(tiles)
 }
 
-pub async fn get_wynntils_terrs() -> Result<HashMap<Arc<str>, Territory>, reqwest::Error> {
+pub async fn _get_wynntils_terrs() -> Result<HashMap<Arc<str>, Territory>, reqwest::Error> {
     let resp: HashMap<Arc<str>, Territory> =
         reqwest::get(format!("{}{}", get_url("http"), "/api/v1/territories/list"))
             .await?

--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -13,7 +13,7 @@ use wynnmap_types::{ExTerrInfo, Territory, WynntilsMapTile, ws::TerrSockMessage}
 pub fn get_url(protocol: &str) -> String {
     let window = leptos::leptos_dom::helpers::window().location();
     let host = window.host().unwrap();
-    let proto = window.protocol().map_or(false, |p| p == "https:");
+    let proto = window.protocol().is_ok_and(|p| p == "https:");
 
     format!("{protocol}{}://{host}", if proto { "s" } else { "" })
 }

--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -76,7 +76,7 @@ pub fn ws_terr_changes(
                 TerrSockMessage::Territory(hash_map) => {
                     terrs.write().extend(hash_map);
                 }
-                TerrSockMessage::Capture { name, old, new } => {
+                TerrSockMessage::Capture { name, old: _, new } => {
                     terrs.write().insert(name, new);
                 }
             }

--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -28,7 +28,7 @@ pub async fn load_map_tiles() -> Option<Vec<WynntilsMapTile>> {
     Some(tiles)
 }
 
-pub async fn _get_wynntils_terrs() -> Result<HashMap<Arc<str>, Territory>, reqwest::Error> {
+pub async fn get_wynntils_terrs() -> Result<HashMap<Arc<str>, Territory>, reqwest::Error> {
     let resp: HashMap<Arc<str>, Territory> =
         reqwest::get(format!("{}{}", get_url("http"), "/api/v1/territories/list"))
             .await?
@@ -76,7 +76,7 @@ pub fn ws_terr_changes(
                 TerrSockMessage::Territory(hash_map) => {
                     terrs.write().extend(hash_map);
                 }
-                TerrSockMessage::Capture { name, old: _, new } => {
+                TerrSockMessage::Capture { name, old: Territory, new } => {
                     terrs.write().insert(name, new);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use components::{checkbox::Checkbox, gleaderboard::Gleaderboard};
 use datasource::ws_terr_changes;
 use leptos::prelude::*;
 use settings::{provide_settings, use_toggle};
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap};
 use wynnmap::{WynnMap, conns::Connections, maptile::DefaultMapTiles, terrs::TerrView};
 
 mod components;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use components::{checkbox::Checkbox, gleaderboard::Gleaderboard};
 use datasource::ws_terr_changes;
 use leptos::prelude::*;
 use settings::{provide_settings, use_toggle};
-use std::{collections::HashMap};
+use std::collections::HashMap;
 use wynnmap::{WynnMap, conns::Connections, maptile::DefaultMapTiles, terrs::TerrView};
 
 mod components;


### PR DESCRIPTION
literally just what warnings came up.  
Started with trunk warnings, then cargo check warnings, then cargo clippy, then rust analyzer came up with a unnecessary brackets